### PR TITLE
Run schedule.yml an hour after update

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -2,7 +2,7 @@ name: Update scoop_directory.db
 
 on:
   schedule:
-  - cron: '1 */12 * * *'
+  - cron: '0 16 * * *'
 
 jobs:
   update-db:


### PR DESCRIPTION
As 
https://github.com/rasa/scoop-directory/blob/master/.github/workflows/update-index.yml#L8-L19 
has
```text
    # run at 15:00 UTC every day (8am PDT/UTC-7)
    - cron: '0 15 * * *'
 ```